### PR TITLE
m8: update bloblist for new adreno libs

### DIFF
--- a/common-proprietary-files.txt
+++ b/common-proprietary-files.txt
@@ -230,12 +230,15 @@ etc/firmware/widevine.b03
 etc/firmware/widevine.mdt
 
 # Graphics
+vendor/firmware/a330_pfp.fw
+vendor/firmware/a330_pm4.fw
 vendor/lib/egl/eglsubAndroid.so
 vendor/lib/egl/libEGL_adreno.so
 vendor/lib/egl/libGLESv1_CM_adreno.so
 vendor/lib/egl/libGLESv2_adreno.so
 vendor/lib/egl/libq3dtools_adreno.so
 vendor/lib/libadreno_utils.so
+vendor/lib/libbccQTI.so
 vendor/lib/libC2D2.so
 vendor/lib/libc2d30-a3xx.so
 vendor/lib/libc2d30.so
@@ -248,17 +251,6 @@ vendor/lib/librs_adreno_sha1.so
 vendor/lib/librs_adreno.so
 vendor/lib/libRSDriver_adreno.so
 vendor/lib/libsc-a3xx.so
-
-# Graphics firmware
-etc/firmware/a225p5_pm4.fw
-etc/firmware/a225_pfp.fw
-etc/firmware/a225_pm4.fw
-etc/firmware/a300_pfp.fw
-etc/firmware/a300_pm4.fw
-etc/firmware/a330_pfp.fw
-etc/firmware/a330_pm4.fw
-etc/firmware/leia_pfp_470.fw
-etc/firmware/leia_pm4_470.fw
 
 # HTC / Other
 -app/EasyAccessService/EasyAccessService.apk


### PR DESCRIPTION
- also remove adreno firmware we don't use

Change-Id: I3ccd5042c2039c2d4f43faac7e23eab0ae7f4923
