### PR TITLE
camera: fix unused variable warning

### DIFF
--- a/camera/CameraWrapper.cpp
+++ b/camera/CameraWrapper.cpp
@@ -431,7 +431,7 @@ static char *camera_get_parameters(struct camera_device *device)
     return params;
 }
 
-static void camera_put_parameters(struct camera_device *device, char *params)
+static void camera_put_parameters(struct camera_device *device __unused, char *params)
 {
     if (params)
         free(params);


### PR DESCRIPTION
Change-Id: Icf3bfdb09ac680af9b30477abe7a13d21619c78d
